### PR TITLE
fix: errors on startup when non-graceful exit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/wastrachan/docker-kea/
 LABEL org.opencontainers.image.licenses="MIT"
 
 RUN apk --no-cache add kea kea-hook-ha kea-ctrl-agent
-RUN mkdir /config /run/kea/
+RUN mkdir /config /run/kea && chmod 750 /run/kea
 
 COPY overlay/ /
 VOLUME /config

--- a/overlay/docker-entrypoint.sh
+++ b/overlay/docker-entrypoint.sh
@@ -14,5 +14,9 @@ if [ ! -f "/config/kea.conf" ]; then
     cp /defaults/kea.conf /config/kea.conf
 fi
 
+# Clean /run/kea
+echo "    [+] Cleaning /run/kea directory"
+rm -f /run/kea/*
+
 echo ""
 exec "$@"


### PR DESCRIPTION
Resolves errors with existing run files when the container is restarted due to a non-graceful shutdown. When kea starts, if the `/run/kea/*` files exist we can be left in a state where kea will refuse to start. This is fixed by ensuring `/run/kea` directory is clean during start and we also make sure the correct permissions exist.

This also means that in my use case I no longer volume mount /run/kea as it is not necessary.